### PR TITLE
introduce template for regular meet up issues

### DIFF
--- a/edition-planning-issue-template.md
+++ b/edition-planning-issue-template.md
@@ -1,0 +1,16 @@
+# Plan
+- [ ] Create meetup.com event
+- [ ] Agenda
+- [ ] prepare katas if applicable
+- [ ] Location
+- [ ] Format
+- [ ] Announce meetup.com event (triggers mail)
+
+# Execute
+- **Date:** Month xxth
+- **Location:** Awesome Venue
+
+Agenda:
+- 18:00 Open the doors 
+- 18:30 Welcome 
+- ...


### PR DESCRIPTION
Any thoughts? Did I miss something?

I used it for the March edition and felt quite comfortable to have this at hand. This should also help future organisers to jump into organising a monthly edition.

@lydG

TODO:
- [x] after merge apply this to "all" left `regular meetup` issues
